### PR TITLE
Use HTML and CSS in template literal to create toolbar

### DIFF
--- a/src/toolbar/dom/create-entity.ts
+++ b/src/toolbar/dom/create-entity.ts
@@ -1,41 +1,53 @@
-import type { DevToolbarCard } from "astro/runtime/client/dev-toolbar/ui-library/card.js";
 import type { Entity } from "../types/entity";
 
 /**
- * Creates a card for an entity.
+ * Creates cards for the entities.
  */
-export function createEntity(data: Entity, baseUrl?: string): DevToolbarCard {
-  // Create the main card
-  const main = document.createElement("astro-dev-toolbar-card");
+export function createEntities(data: Array<Entity>, baseUrl: string): string {
+  return /* HTML */ `
+    <style>
+      .entity {
+        position: relative;
 
-  // Create the main content container
-  const content = document.createElement("div");
-  content.style.position = "relative";
-  main.appendChild(content);
+        pre {
+          margin: 0;
+          overflow: auto;
+        }
 
-  // Add the "View in PocketBase" button
-  if (baseUrl) {
-    const url = `${baseUrl}/_/#/collections?collection=${data.collectionId}&recordId=${data.id}`;
+        astro-dev-toolbar-button {
+          position: absolute;
+          top: 0;
+          right: 0;
+        }
+      }
+    </style>
 
-    const viewInPocketbase = document.createElement("astro-dev-toolbar-button");
-    viewInPocketbase.size = "small";
-    viewInPocketbase.buttonStyle = "purple";
-    viewInPocketbase.textContent = "View in PocketBase";
-    viewInPocketbase.style.position = "absolute";
-    viewInPocketbase.style.top = "0";
-    viewInPocketbase.style.right = "0";
-    viewInPocketbase.addEventListener("click", () => {
-      window.open(url, "_blank");
-    });
-    content.appendChild(viewInPocketbase);
-  }
+    ${data.map((entity) => createEntity(entity, baseUrl)).join("")}
+  `;
+}
 
-  // Add the entity data
-  const entity = document.createElement("pre");
-  entity.style.margin = "0";
-  entity.style.overflow = "auto";
-  entity.textContent = JSON.stringify(data, null, 2);
-  content.appendChild(entity);
+/**
+ * Creates a card for a single entity
+ */
+function createEntity(data: Entity, baseUrl: string): string {
+  return /* HTML */ `
+    <astro-dev-toolbar-card>
+      <div class="entity">
+        <pre>${JSON.stringify(data, null, 2).replaceAll(/</g, "&lt;")}</pre>
 
-  return main;
+        ${baseUrl
+          ? /* HTML */ `
+              <astro-dev-toolbar-button
+                size="small"
+                button-style="purple"
+                title="View in PocketBase"
+                onclick="window.open('${baseUrl}/_/#/collections?collection=${data.collectionId}&recordId=${data.id}', '_blank')"
+              >
+                View in PocketBase
+              </astro-dev-toolbar-button>
+            `
+          : ""}
+      </div>
+    </astro-dev-toolbar-card>
+  `;
 }

--- a/src/toolbar/dom/create-placeholder.ts
+++ b/src/toolbar/dom/create-placeholder.ts
@@ -1,23 +1,22 @@
-import type { DevToolbarCard } from "astro/runtime/client/dev-toolbar/ui-library/card.js";
-
 /**
  * Creates a placeholder card.
  */
-export function createPlaceholder(): DevToolbarCard {
-  // Create the main card
-  const main = document.createElement("astro-dev-toolbar-card");
+export function createPlaceholder(): string {
+  return /* HTML */ `
+    <style>
+      #placeholder {
+        > div {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+      }
+    </style>
 
-  // Create the main content container
-  const content = document.createElement("div");
-  content.style.display = "flex";
-  content.style.alignItems = "center";
-  content.style.justifyContent = "center";
-  main.appendChild(content);
-
-  // Add the placeholder text
-  const placeholder = document.createElement("span");
-  placeholder.textContent = "Here you will see the raw content of an entity";
-  content.appendChild(placeholder);
-
-  return main;
+    <astro-dev-toolbar-card id="placeholder">
+      <div>
+        <span> Here you will see the raw content of an entity </span>
+      </div>
+    </astro-dev-toolbar-card>
+  `;
 }


### PR DESCRIPTION
Instead of building the toolbar elements imperatively, it is now declared in HTML and CSS inside of template literals. This makes it much easier to add layout elements or add styling via CSS.

The toolbar now also uses internal functions by Astro to create the window element, to synchronize the window placement and to close the window on outside click. This removes some of the previous hacks and refactors the window to be more like the first party integrations.